### PR TITLE
deep copy of TableSchema

### DIFF
--- a/dbxio/__init__.py
+++ b/dbxio/__init__.py
@@ -4,4 +4,4 @@ from dbxio.sql import *  # noqa: F403
 from dbxio.utils import *  # noqa: F403
 from dbxio.volume import *  # noqa: F403
 
-__version__ = '0.1.0.post2'  # single source of truth
+__version__ = '0.1.1'  # single source of truth

--- a/dbxio/delta/table_schema.py
+++ b/dbxio/delta/table_schema.py
@@ -1,3 +1,4 @@
+import copy
 from functools import cache
 from typing import Any
 
@@ -27,6 +28,15 @@ class TableSchema:
         except IndexError:
             raise AttributeError(f'Column {item} not found in schema. Possible columns: {self.columns}')
         return column
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+
+        for k, v in self.__dict__.items():
+            setattr(result, k, copy.deepcopy(v, memo))
+
+        return result
 
     @classmethod
     def from_obj(cls, obj):


### PR DESCRIPTION
Some tools, such as Airflow, perform copies of variables under the hood. Previously, the `TableSchema` class could not be deep copied because it uses dynamic column addressing via `getattr`.

This PR fixes a bug that caused a `RecursionError` and now supports the correct deep copy of `TableSchema`.