### PR TITLE
feat: make possible to run w/o retries

### DIFF
--- a/dbxio/__init__.py
+++ b/dbxio/__init__.py
@@ -4,4 +4,4 @@ from dbxio.sql import *  # noqa: F403
 from dbxio.utils import *  # noqa: F403
 from dbxio.volume import *  # noqa: F403
 
-__version__ = '0.5.1'  # single source of truth
+__version__ = '0.5.2'  # single source of truth

--- a/dbxio/core/settings.py
+++ b/dbxio/core/settings.py
@@ -19,7 +19,7 @@ def _cloud_provider_factory() -> CloudProvider:
 
 @attrs.frozen
 class RetryConfig:
-    max_attempts: int = attrs.field(default=7, validator=[attrs.validators.instance_of(int), attrs.validators.ge(1)])
+    max_attempts: int = attrs.field(default=7, validator=[attrs.validators.instance_of(int), attrs.validators.ge(0)])
     exponential_backoff_multiplier: Union[float, int] = attrs.field(
         default=1.0,
         validator=[attrs.validators.instance_of((float, int)), attrs.validators.ge(0)],
@@ -31,6 +31,10 @@ class RetryConfig:
             iterable_validator=attrs.validators.instance_of(tuple),
         ),
     )
+
+    @property
+    def empty(self):
+        return self.max_attempts == 0
 
 
 @attrs.define


### PR DESCRIPTION
PR makes possible to use `dbxio` without retries:

```python
client = dbxio.DbxIOClient.from_cluster_settings(
   ...
   settings=dbxio.Settings(retry_config=dbxio.RetryConfig(max_attempts=0))
   ...
)
```